### PR TITLE
Update Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,3 @@ AllCops:
 
 Layout/LineLength:
   Max: 80
-
-Lint/Debugger:
-  DebuggerMethods:
-    Kernel:
-      p: ~


### PR DESCRIPTION
remove dubbger methods config (removed in rubocop 1.46 as well)